### PR TITLE
Solution to task 10-architecture - 01-RenderlessCalendar

### DIFF
--- a/10-architeture/01-RenderlessCalendar/components/CalendarView.vue
+++ b/10-architeture/01-RenderlessCalendar/components/CalendarView.vue
@@ -19,7 +19,7 @@
                :class="{ rangepicker__cell_inactive: day.isInactive }"
                v-for="day in daysArray"
           >
-            {{ day.dayNum }}
+            {{ day.currentDate.getDate() }}
             <slot :currentDate="day.currentDate"></slot>
           </div>
         </div>

--- a/10-architeture/01-RenderlessCalendar/components/CalendarView.vue
+++ b/10-architeture/01-RenderlessCalendar/components/CalendarView.vue
@@ -20,7 +20,7 @@
                v-for="day in daysArray"
           >
             {{ day.dayNum }}
-            <slot :day="day"></slot>
+            <slot :currentDate="day.currentDate"></slot>
           </div>
         </div>
       </div>

--- a/10-architeture/01-RenderlessCalendar/components/CalendarView.vue
+++ b/10-architeture/01-RenderlessCalendar/components/CalendarView.vue
@@ -1,25 +1,28 @@
 <template>
-  <renderless-calendar class="rangepicker">
-    <div class="rangepicker__calendar">
-      <div class="rangepicker__month-indicator">
-        <div class="rangepicker__selector-controls">
-          <button class="rangepicker__selector-control-left"></button>
-          <div>Январь 2021</div>
-          <button class="rangepicker__selector-control-right"></button>
+  <renderless-calendar
+    class="rangepicker"
+    :month="month"
+    :year="year"
+    v-slot="{daysArray, prevMonth, nextMonth, currentMonthLocal, currentFullYear}"
+  >
+    <div class="rangepicker">
+      <div class="rangepicker__calendar">
+        <div class="rangepicker__month-indicator">
+          <div class="rangepicker__selector-controls">
+            <button class="rangepicker__selector-control-left" @click="prevMonth"></button>
+            <div>{{ currentMonthLocal }} {{ currentFullYear }}</div>
+            <button class="rangepicker__selector-control-right" @click="nextMonth"></button>
+          </div>
         </div>
-      </div>
-      <div class="rangepicker__date-grid">
-        <div class="rangepicker__cell rangepicker__cell_inactive">28</div>
-        <div class="rangepicker__cell rangepicker__cell_inactive">29</div>
-        <div class="rangepicker__cell rangepicker__cell_inactive">30</div>
-        <div class="rangepicker__cell rangepicker__cell_inactive">31</div>
-        <div class="rangepicker__cell">
-          1
-          <a class="rangepicker__event">Митап</a>
-          <a class="rangepicker__event">Митап</a>
+        <div class="rangepicker__date-grid">
+          <div class="rangepicker__cell"
+               :class="{ rangepicker__cell_inactive: day.isInactive }"
+               v-for="day in daysArray"
+          >
+            {{ day.dayNum }}
+            <slot :day="day"></slot>
+          </div>
         </div>
-        <div class="rangepicker__cell">2</div>
-        <div class="rangepicker__cell">3</div>
       </div>
     </div>
   </renderless-calendar>
@@ -31,7 +34,18 @@ import RenderlessCalendar from './RenderlessCalendar';
 export default {
   name: 'CalendarView',
 
-  components: { RenderlessCalendar },
+  components: {RenderlessCalendar},
+
+  props: {
+    month: {
+      type: Number,
+      default: (new Date()).getMonth()
+    },
+    year: {
+      type: Number,
+      default: (new Date()).getFullYear()
+    }
+  }
 };
 </script>
 
@@ -74,6 +88,7 @@ export default {
   justify-content: space-between;
   text-transform: capitalize;
 }
+
 .rangepicker__selector-controls button {
   border: none;
   padding: 0;

--- a/10-architeture/01-RenderlessCalendar/components/CalendarView.vue
+++ b/10-architeture/01-RenderlessCalendar/components/CalendarView.vue
@@ -30,7 +30,6 @@
 
 <script>
 import RenderlessCalendar from './RenderlessCalendar';
-
 export default {
   name: 'CalendarView',
 
@@ -39,11 +38,11 @@ export default {
   props: {
     month: {
       type: Number,
-      default: (new Date()).getMonth()
+      default: () => new Date().getMonth()
     },
     year: {
       type: Number,
-      default: (new Date()).getFullYear()
+      default: () => new Date().getFullYear()
     }
   }
 };

--- a/10-architeture/01-RenderlessCalendar/components/MeetupsCalendar.vue
+++ b/10-architeture/01-RenderlessCalendar/components/MeetupsCalendar.vue
@@ -1,9 +1,9 @@
 <template>
   <calendar-view :month="4" :year="2020">
-    <template #default="{day}">
+    <template #default="{currentDate}">
       <calendar-view-event
         v-for="meetup in meetups"
-        v-if="new Date(meetup.date).getMonth() === day.monthNum && new Date(meetup.date).getDate() === day.dayNum"
+        v-if="new Date(meetup.date).getMonth() === currentDate.getMonth() && new Date(meetup.date).getDate() === currentDate.getDate() && new Date(meetup.date).getFullYear() === currentDate.getFullYear()"
         tag="router-link"
         :to="{ name: 'meetup', params: { meetupId: meetup.id } }"
       >

--- a/10-architeture/01-RenderlessCalendar/components/MeetupsCalendar.vue
+++ b/10-architeture/01-RenderlessCalendar/components/MeetupsCalendar.vue
@@ -1,9 +1,9 @@
 <template>
-  <calendar-view :month="4" :year="2020">
+  <calendar-view>
     <template #default="{currentDate}">
       <calendar-view-event
-        v-for="meetup in meetups"
-        v-if="new Date(meetup.date).getMonth() === currentDate.getMonth() && new Date(meetup.date).getDate() === currentDate.getDate() && new Date(meetup.date).getFullYear() === currentDate.getFullYear()"
+        v-for="meetup in meetupsByDate[currentDate.toDateString()]"
+        :key="meetup.id"
         tag="router-link"
         :to="{ name: 'meetup', params: { meetupId: meetup.id } }"
       >
@@ -26,11 +26,24 @@ export default {
       required: true,
     },
   },
-
+  computed: {
+    meetupsByDate() {
+      const result = {};
+      this.meetups.forEach((meetup) => {
+        const dateString = new Date(meetup.date).toDateString();
+        if (!result[dateString]) {
+          result[dateString] = [meetup];
+        } else {
+          result[dateString].push(meetup);
+        }
+      });
+      return result;
+    },
+  },
   components: {
     CalendarViewEvent,
     CalendarView,
-  },
+  }
 };
 </script>
 

--- a/10-architeture/01-RenderlessCalendar/components/MeetupsCalendar.vue
+++ b/10-architeture/01-RenderlessCalendar/components/MeetupsCalendar.vue
@@ -1,12 +1,15 @@
 <template>
-  <calendar-view>
-    <!--
-    <calendar-view-event
-      tag="router-link"
-      :to="{ name: 'meetup', params: { meetupId: meetup.id } }"
-      >{{ meetup.title }}</calendar-view-event
-    >
-    -->
+  <calendar-view :month="4" :year="2020">
+    <template #default="{day}">
+      <calendar-view-event
+        v-for="meetup in meetups"
+        v-if="new Date(meetup.date).getMonth() === day.monthNum && new Date(meetup.date).getDate() === day.dayNum"
+        tag="router-link"
+        :to="{ name: 'meetup', params: { meetupId: meetup.id } }"
+      >
+        {{ meetup.title }}
+      </calendar-view-event>
+    </template>
   </calendar-view>
 </template>
 

--- a/10-architeture/01-RenderlessCalendar/components/RenderlessCalendar.vue
+++ b/10-architeture/01-RenderlessCalendar/components/RenderlessCalendar.vue
@@ -41,14 +41,8 @@ export default {
 
       for (let i = 1 - prevDays; daysArray.length < total; i++) {
         currentDate = new Date(this.currentFullYear, this.currentMonth, i);
-        let currentDateStr = currentDate.toLocaleString(navigator.language, {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric'
-        });
         daysArray.push({
             currentDate: currentDate,
-            dayNum: currentDate.getDate(),
             isInactive: (daysArray.length < prevDays) || (daysArray.length >= (total - nextDays)),
           }
         );

--- a/10-architeture/01-RenderlessCalendar/components/RenderlessCalendar.vue
+++ b/10-architeture/01-RenderlessCalendar/components/RenderlessCalendar.vue
@@ -3,10 +3,12 @@ export default {
   name: 'RenderlessCalendar',
   props: {
     month: {
-      type: Number
+      type: Number,
+      default: () => new Date().getMonth()
     },
     year: {
       type: Number,
+      default: () => new Date().getFullYear()
     }
   },
   data() {

--- a/10-architeture/01-RenderlessCalendar/components/RenderlessCalendar.vue
+++ b/10-architeture/01-RenderlessCalendar/components/RenderlessCalendar.vue
@@ -1,7 +1,79 @@
 <script>
 export default {
   name: 'RenderlessCalendar',
+  props: {
+    month: {
+      type: Number
+    },
+    year: {
+      type: Number,
+    }
+  },
+  data() {
+    return {
+      date: new Date(this.year, this.month),
+    }
+  },
+  computed: {
+    currentMonth(){
+      return this.date.getMonth()
+    },
+    currentMonthLocal() {
+      return this.date.toLocaleString(navigator.language, {
+        month: 'long',
+      })
+    },
+    currentFullYear(){
+      return this.date.getFullYear()
+    },
+    daysArray(){
+      let currentDate;
+      let prevDays;
+      let nextDays;
+      let firstDay = new Date(this.currentFullYear, this.currentMonth, 1).getDay();
+      let lastDay = new Date(this.currentFullYear, this.currentMonth + 1, 0).getDay();
+      let daysArray = [];
 
-  render(h) {},
+      firstDay === 0 ? prevDays = 6 : prevDays = firstDay - 1;
+      lastDay === 0 ? nextDays = 0 : nextDays = 7 - lastDay;
+
+      let total = prevDays + (new Date(this.currentFullYear, this.currentMonth+1, 0).getDate()) + nextDays;
+
+      for (let i = 1 - prevDays; daysArray.length < total; i++) {
+        currentDate = new Date(this.currentFullYear, this.currentMonth, i);
+        let currentDateStr = currentDate.toLocaleString(navigator.language, {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric'
+        });
+        daysArray.push({
+            monthNum: currentDate.getMonth(),
+            dayNum: currentDate.getDate(),
+            isInactive: (daysArray.length < prevDays) || (daysArray.length >= (total - nextDays)),
+          }
+        );
+      }
+      return daysArray;
+    }
+  },
+
+  methods: {
+    prevMonth(){
+      this.date = new Date(this.currentFullYear, this.currentMonth-1);
+    },
+    nextMonth(){
+      this.date = new Date(this.currentFullYear, this.currentMonth+1);
+    }
+  },
+
+  render() {
+    return this.$scopedSlots.default({
+      daysArray: this.daysArray,
+      prevMonth: this.prevMonth,
+      nextMonth: this.nextMonth,
+      currentMonthLocal: this.currentMonthLocal,
+      currentFullYear: this.currentFullYear
+    });
+  },
 };
 </script>

--- a/10-architeture/01-RenderlessCalendar/components/RenderlessCalendar.vue
+++ b/10-architeture/01-RenderlessCalendar/components/RenderlessCalendar.vue
@@ -47,7 +47,7 @@ export default {
           day: 'numeric'
         });
         daysArray.push({
-            monthNum: currentDate.getMonth(),
+            currentDate: currentDate,
             dayNum: currentDate.getDate(),
             isInactive: (daysArray.length < prevDays) || (daysArray.length >= (total - nextDays)),
           }


### PR DESCRIPTION
Добавил возможность указать во входных параметрах компонентов ```RenderlessCalendar``` и ```CalendarView``` не только месяц, но и год. При добавлении этих параметров тесты теперь не проходят, хотя визуально все отображается корректно. Григорий, подскажите почему :)